### PR TITLE
Add assertions to package files

### DIFF
--- a/src/main/java/tkit/Command.java
+++ b/src/main/java/tkit/Command.java
@@ -17,6 +17,7 @@ enum Command {
     private final String keyword;
 
     Command(String keyword) {
+        assert keyword != null : "Command keyword must not be null";
         this.keyword = keyword;
     }
 
@@ -33,6 +34,7 @@ enum Command {
      */
     public static Command fromInput(String input) {
         String s = input == null ? "" : input.toLowerCase();
+        assert s.equals(s.toLowerCase()) : "Lowercasing should be idempotent";
         for (Command c : values()) {
             if (!c.keyword.isEmpty() && c.keyword.equals(s)) {
                 return c;

--- a/src/main/java/tkit/CommandProcessor.java
+++ b/src/main/java/tkit/CommandProcessor.java
@@ -9,17 +9,21 @@ final class CommandProcessor {
     private final TaskList tasks;
 
     CommandProcessor() {
-        this.tasks = new TaskList(storage.load());
+        List<Task> loaded = storage.load();
+        assert loaded != null : "Storage.load() must return non-null list";
+        this.tasks = new TaskList(loaded);
     }
 
     boolean isExit(String rawLine) {
         Parser.SplitCommand parsed = Parser.parse(rawLine);
+        assert parsed != null;
         return parsed.command == Command.BYE;
     }
 
     String handle(String rawLine) {
         String line = rawLine == null ? "" : rawLine.trim();
         Parser.SplitCommand parsed = Parser.parse(line);
+        assert parsed != null : "Parser must not return null";
 
         try {
             switch (parsed.command) {
@@ -82,6 +86,7 @@ final class CommandProcessor {
 
             case MARK: {
                 int idx = parseIndex(parsed.argOrEmpty(), tasks.size());
+                assert idx >= 0 && idx < tasks.size();
                 tasks.mark(idx);
                 storage.save(tasks.view());
                 return block("Marked as done:\n  " + tasks.get(idx));
@@ -154,7 +159,9 @@ final class CommandProcessor {
     }
 
     private static int parseIndex(String userSuppliedIndex, int currentSize) throws TkitException {
+        assert currentSize >= 0 : "currentSize must be non-negative";
         String trimmed = userSuppliedIndex.trim();
+        assert !trimmed.isEmpty() : "index string pre-validated to be non-empty";
         try {
             int oneBased = Integer.parseInt(trimmed);
             int zeroBased = oneBased - 1;
@@ -168,6 +175,7 @@ final class CommandProcessor {
     }
 
     private static String renderList(List<Task> tasks) {
+        assert tasks != null : "renderList(): tasks must not be null";
         StringBuilder sb = new StringBuilder();
         if (tasks.isEmpty()) {
             sb.append("There are no entries yet.");

--- a/src/main/java/tkit/DateTimeUtil.java
+++ b/src/main/java/tkit/DateTimeUtil.java
@@ -63,6 +63,7 @@ final class DateTimeUtil {
      * @throws IllegalArgumentException if parsing fails
      */
     public static LocalDateTime parseToLdt(String raw) {
+        assert raw != null && !raw.isBlank() : "parseToLdt(): raw must be non-blank";
         String s = raw.trim();
         try {
             return LocalDateTime.parse(s, INPUT_FMT);
@@ -108,6 +109,7 @@ final class DateTimeUtil {
      * @return formatted string
      */
     public static String pretty(LocalDateTime ldt) {
+        assert ldt != null : "pretty(ldt): null";
         if (ldt.toLocalTime().equals(LocalTime.MIDNIGHT)) {
             return ldt.format(OUT_DATE);
         }
@@ -116,6 +118,7 @@ final class DateTimeUtil {
 
     /** Pretty-print for a LocalDate using the same OUT_DATE pattern. */
     public static String pretty(LocalDate date) {
+        assert date != null : "pretty(date): null";
         return date.format(OUT_DATE);
     }
 

--- a/src/main/java/tkit/Deadline.java
+++ b/src/main/java/tkit/Deadline.java
@@ -14,6 +14,9 @@ class Deadline extends Task {
      */
     public Deadline(String description, LocalDateTime dueAt) {
         super(TaskType.DEADLINE, description);
+
+        assert dueAt != null : "Event endpoints must not be null";
+
         this.dueAt = dueAt;
     }
 
@@ -24,6 +27,7 @@ class Deadline extends Task {
 
     @Override
     public String toString() {
+        assert dueAt != null : "Deadline must have dueAt";
         return super.toString() + " (by: " + DateTimeUtil.pretty(dueAt) + ")";
     }
 }

--- a/src/main/java/tkit/Event.java
+++ b/src/main/java/tkit/Event.java
@@ -16,17 +16,23 @@ class Event extends Task {
      */
     public Event(String description, LocalDateTime from, LocalDateTime to) {
         super(TaskType.EVENT, description);
+
+        assert from != null && to != null : "Event endpoints must not be null";
+        assert !to.isBefore(from) : "Event end must be >= start";
+
         this.from = from;
         this.to = to;
     }
 
     /** Returns the start date/time. */
     public LocalDateTime getFrom() {
+        assert from != null;
         return from;
     }
 
     /** Returns the end date/time. */
     public LocalDateTime getTo() {
+        assert to != null;
         return to;
     }
 

--- a/src/main/java/tkit/Parser.java
+++ b/src/main/java/tkit/Parser.java
@@ -20,6 +20,7 @@ final class Parser {
         final String remainder;
 
         SplitCommand(Command command, String remainder) {
+            assert command != null : "Command must not be null";
             this.command = command;
             this.remainder = remainder == null ? "" : remainder;
         }
@@ -45,8 +46,13 @@ final class Parser {
             return new SplitCommand(Command.UNKNOWN, "");
         }
         String[] parts = normalized.split("\\s+", 2);
+        assert parts.length >= 1 : "Split must yield at least a command token";
+
         Command cmd = Command.fromInput(parts[0]);
+
         String rest = parts.length > 1 ? parts[1] : "";
+        assert rest != null : "Remainder must not be null";
+
         return new SplitCommand(cmd, rest);
     }
 }

--- a/src/main/java/tkit/Status.java
+++ b/src/main/java/tkit/Status.java
@@ -8,11 +8,13 @@ enum Status {
     private final String stateIcon;
 
     Status(String stateIcon) {
+        assert stateIcon != null && stateIcon.length() == 1 : "State icon must be exactly one char";
         this.stateIcon = stateIcon;
     }
 
     /** Returns the one-character state icon used in list rendering. */
     public String stateIcon() {
+
         return stateIcon;
     }
 }

--- a/src/main/java/tkit/Storage.java
+++ b/src/main/java/tkit/Storage.java
@@ -87,6 +87,7 @@ final class Storage {
      * @param tasks current snapshot of tasks to save
      */
     public void save(List<Task> tasks) {
+        assert tasks != null : "save(): tasks must not be null";
         ensureParentDir();
         Path tmp = dataFile.resolveSibling(dataFile.getFileName() + ".tmp");
 
@@ -129,8 +130,10 @@ final class Storage {
 
     /** Ensures parent directory exists; creates it if missing. */
     private void ensureParentDir() {
+
         try {
             Path parent = dataFile.getParent();
+            assert parent != null : "Data file must have a parent directory";
             if (parent != null && !Files.exists(parent)) {
                 Files.createDirectories(parent);
             }
@@ -141,6 +144,10 @@ final class Storage {
 
     /** Serializes a task into a single line. */
     private String encodeTask(Task t) {
+        assert t != null : "encodeTask(): task is null";
+        assert t.type != null && t.status != null
+                && t.description != null : "encodeTask(): fields must be non-null";
+
         String doneFlag = (t.status == Status.DONE) ? "1" : "0";
         String type = t.type.tag();
 
@@ -173,6 +180,7 @@ final class Storage {
      * @return constructed task or {@code null} if corrupted
      */
     private Task decodeLine(String line) {
+        assert line != null && !line.isBlank() : "decodeLine(): empty line";
         List<String> rawFields = splitPreservingEscapes(line);
         if (rawFields.size() < 3) {
             return null;
@@ -228,11 +236,13 @@ final class Storage {
 
     /** Escapes literal backslashes and pipes within a field. */
     private static String escape(String s) {
+        assert s != null : "escape(): null";
         return s.replace("\\", "\\\\").replace("|", "\\|");
     }
 
     /** Reverses {@link #escape(String)} on a field. */
     private static String unescape(String s) {
+        assert s != null : "unescape(): null";
         StringBuilder out = new StringBuilder();
         boolean escaping = false;
         for (int i = 0; i < s.length(); i++) {
@@ -254,6 +264,7 @@ final class Storage {
 
     /** Splits a line by unescaped {@code |}, preserving escaped separators. */
     private static List<String> splitPreservingEscapes(String line) {
+        assert line != null : "splitPreservingEscapes(): null";
         List<String> fields = new ArrayList<>();
         StringBuilder current = new StringBuilder();
         boolean escaping = false;

--- a/src/main/java/tkit/Task.java
+++ b/src/main/java/tkit/Task.java
@@ -13,6 +13,8 @@ abstract class Task {
      * @param description user-visible text
      */
     protected Task(TaskType type, String description) {
+        assert type != null : "Task type must not be null";
+        assert description != null && !description.isBlank() : "Task description must not be blank";
         this.type = type;
         this.description = description;
         this.status = Status.NOT_DONE;
@@ -20,11 +22,13 @@ abstract class Task {
 
     /** Marks this task as done. */
     public void markAsDone() {
+        assert this.status != null : "Status must be initialized";
         this.status = Status.DONE;
     }
 
     /** Marks this task as not done. */
     public void markAsUndone() {
+        assert this.status != null : "Status must be initialized";
         this.status = Status.NOT_DONE;
     }
 
@@ -48,6 +52,7 @@ abstract class Task {
     /** Renders as {@code [Type][State] Description}. */
     @Override
     public String toString() {
+        assert type != null && status != null && description != null;
         return "[" + type.tag() + "][" + status.stateIcon() + "] " + description;
     }
 }

--- a/src/main/java/tkit/TaskList.java
+++ b/src/main/java/tkit/TaskList.java
@@ -19,6 +19,7 @@ final class TaskList {
     /** Creates an empty task list. */
     TaskList() {
         this.tasks = new ArrayList<>();
+        assert this.tasks.isEmpty();
     }
 
     /**
@@ -29,6 +30,7 @@ final class TaskList {
      */
     TaskList(List<Task> initial) {
         this.tasks = new ArrayList<>(initial == null ? List.of() : initial);
+        assert this.tasks != null;
     }
 
     /**
@@ -57,6 +59,7 @@ final class TaskList {
      * @throws IndexOutOfBoundsException if {@code idx} is invalid
      */
     Task get(int idx) {
+        assert idx >= 0 && idx < tasks.size() : "get(): index out of bounds";
         return tasks.get(idx);
     }
 
@@ -75,7 +78,10 @@ final class TaskList {
      * @param t task to add
      */
     void add(Task t) {
+        assert t != null : "add(): task must not be null";
+        int before = tasks.size();
         tasks.add(t);
+        assert tasks.size() == before + 1 : "add(): size must increase by 1";
     }
 
     /**
@@ -86,6 +92,7 @@ final class TaskList {
      * @throws IndexOutOfBoundsException if {@code idx} is invalid
      */
     Task removeAt(int idx) {
+        assert idx >= 0 && idx < tasks.size() : "removeAt(): index out of bounds";
         return tasks.remove(idx);
     }
 
@@ -95,6 +102,7 @@ final class TaskList {
      * @param idx zero-based index
      */
     void mark(int idx) {
+        assert idx >= 0 && idx < tasks.size() : "mark(): index out of bounds";
         tasks.get(idx).markAsDone();
     }
 
@@ -104,6 +112,7 @@ final class TaskList {
      * @param idx zero-based index
      */
     void unmark(int idx) {
+        assert idx >= 0 && idx < tasks.size() : "unmark(): index out of bounds";
         tasks.get(idx).markAsUndone();
     }
 
@@ -116,10 +125,12 @@ final class TaskList {
     List<Task> find(String keyword) {
         List<Task> hits = new ArrayList<>();
         for (Task t : tasks) {
+            assert t != null : "List must not contain null tasks";
             if (t.containsKeyword(keyword)) {
                 hits.add(t);
             }
         }
+        assert hits.size() <= tasks.size();
         return hits;
     }
 

--- a/src/main/java/tkit/TaskType.java
+++ b/src/main/java/tkit/TaskType.java
@@ -9,11 +9,13 @@ enum TaskType {
     private final String tag;
 
     TaskType(String tag) {
+        assert tag != null && !tag.isBlank() : "TaskType tag must be one non-blank letter";
         this.tag = tag;
     }
 
     /** Returns the single-letter tag for this type. */
     public String tag() {
+
         return tag;
     }
 }

--- a/src/main/java/tkit/Tkit.java
+++ b/src/main/java/tkit/Tkit.java
@@ -36,13 +36,16 @@ public final class Tkit {
         ui.banner(IDENTITY);
 
         TaskList tasks = new TaskList(storage.load());
+        assert tasks != null : "TaskList must be constructed";
 
         try (Scanner input = new Scanner(System.in)) {
             while (true) {
                 String rawLine = input.nextLine().trim();
+                assert rawLine != null : "Scanner returned null line";
 
                 try {
                     SplitCommand parsed = Parser.parse(rawLine);
+                    assert parsed != null;
 
                     switch (parsed.command) {
                     case BYE: {
@@ -209,7 +212,9 @@ public final class Tkit {
      * @throws TkitException if parsing fails or the index is out of range
      */
     private static int parseIndex(String userSuppliedIndex, int currentSize) throws TkitException {
+        assert currentSize >= 0;
         String trimmed = userSuppliedIndex.trim();
+        assert !trimmed.isEmpty();
         try {
             int oneBased = Integer.parseInt(trimmed);
             int zeroBased = oneBased - 1;

--- a/src/main/java/tkit/Ui.java
+++ b/src/main/java/tkit/Ui.java
@@ -36,6 +36,7 @@ final class Ui {
      * @param tasks ordered view of all tasks
      */
     void list(List<Task> tasks) {
+        assert tasks != null;
         System.out.println("____________________\n");
         if (tasks.isEmpty()) {
             System.out.println("There are no entries yet.");
@@ -55,6 +56,7 @@ final class Ui {
      * @param totalCount new total number of tasks
      */
     void added(Task t, int totalCount) {
+        assert t != null && totalCount >= 0;
         System.out.println("____________________\n");
         System.out.println("Got it. I've added this task:");
         System.out.println("  " + t);
@@ -68,6 +70,7 @@ final class Ui {
      * @param t the task that was marked
      */
     void marked(Task t) {
+        assert t != null;
         System.out.println("____________________\n");
         System.out.println("Nice! I've marked this task as done:");
         System.out.println("  " + t);
@@ -80,6 +83,7 @@ final class Ui {
      * @param t the task that was unmarked
      */
     void unmarked(Task t) {
+        assert t != null;
         System.out.println("____________________\n");
         System.out.println("OK, I've marked this task as not done yet:");
         System.out.println("  " + t);
@@ -93,6 +97,7 @@ final class Ui {
      * @param newSize the new size of the task list
      */
     void removed(Task t, int newSize) {
+        assert t != null && newSize >= 0;
         System.out.println("____________________\n");
         System.out.println("Noted. I've removed this task:");
         System.out.println("  " + t);
@@ -106,6 +111,7 @@ final class Ui {
      * @param hits ordered list of tasks that matched
      */
     void matches(List<Task> hits) {
+        assert hits != null;
         System.out.println("____________________\n");
         if (hits.isEmpty()) {
             System.out.println("No matching tasks found.");
@@ -125,6 +131,7 @@ final class Ui {
      * @param hits ordered list of tasks that occur on the date
      */
     void onDate(LocalDate date, List<Task> hits) {
+        assert date != null && hits != null;
         System.out.println("____________________\n");
         if (hits.isEmpty()) {
             System.out.println("No deadlines/events on " + DateTimeUtil.pretty(date) + ".");
@@ -143,6 +150,7 @@ final class Ui {
      * @param msg error message to display
      */
     void error(String msg) {
+        assert msg != null;
         System.out.println("____________________\n");
         System.out.println(msg);
         System.out.println("____________________\n");


### PR DESCRIPTION
Code relies on runtime validation and exceptions; many internal assumptions (non-nulls, index bounds, temporal ordering, resource presence) remain implicit and unverified.

Implicit assumptions allow regressions to slip through refactors, make defects hard to localize, and weaken code readability and maintainability. Early, developer-only checks reduce debugging time and document intent.

Add Java assert statements across package files. Assert non-null/non-blank inputs, index bounds, event end ≥ start, resource existence, storage encoding/decoding invariants, and postconditions on list mutations.

Assertions are zero-overhead in production when disabled, minimally invasive, and complementary to existing user-facing validations and exceptions. They document invariants at the point of use and fail fast in development.

Enable during dev with: java -ea … or Gradle run/test jvmArgs " -ea\.