### PR TITLE
Modify code to fit coding standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Usage:
-## Compile from the project root:
-javac -d out src/main/java/tkit/*.java
-## Run the program
-java -cp out tkit.Tkit
-
+## Run the program (from project root directory)
+./gradlew run 
 
 
 # Duke project template

--- a/src/main/java/tkit/Command.java
+++ b/src/main/java/tkit/Command.java
@@ -31,7 +31,7 @@ enum Command {
      * @param input token (case-insensitive)
      * @return matching command or {@code UNKNOWN}
      */
-    public static Command fromInput(String input) {
+    public static Command getCommandFromInput(String input) {
         String s = input == null ? "" : input.toLowerCase();
         for (Command c : values()) {
             if (!c.keyword.isEmpty() && c.keyword.equals(s)) {

--- a/src/main/java/tkit/DateTimeUtil.java
+++ b/src/main/java/tkit/DateTimeUtil.java
@@ -56,7 +56,7 @@ final class DateTimeUtil {
     private DateTimeUtil() { }
 
     /**
-     * Strict parse; throws on failure.
+     * Parses input string; throws on failure.
      *
      * @param raw input text
      * @return parsed LocalDateTime
@@ -81,7 +81,7 @@ final class DateTimeUtil {
     }
 
     /**
-     * Non-throwing parse; returns null on failure.
+     * Parses input string, returns null on failure.
      *
      * @param raw input text
      * @return LocalDateTime or null
@@ -102,7 +102,8 @@ final class DateTimeUtil {
     }
 
     /**
-     * Pretty-print: omit time if midnight, else include HH:mm.
+     * Prints (pretty-prints) input date-time:
+     * Omits time if midnight, else includes HH:mm.
      *
      * @param ldt date-time
      * @return formatted string
@@ -114,13 +115,13 @@ final class DateTimeUtil {
         return ldt.format(OUT_DATE_TIME);
     }
 
-    /** Pretty-print for a LocalDate using the same OUT_DATE pattern. */
+    /** Prints (Pretty-print) LocalDate using OUT_DATE pattern. */
     public static String pretty(LocalDate date) {
         return date.format(OUT_DATE);
     }
 
     /**
-     * Lossless storage format (ISO-8601).
+     * Stores as lossless storage format (ISO-8601).
      *
      * @param ldt date-time
      * @return ISO-8601 string
@@ -130,7 +131,8 @@ final class DateTimeUtil {
     }
 
     /**
-     * Strict storage parse with fallback to input; throws on failure.
+     * Parses storage text with fallback to input;
+     * Throws on failure.
      *
      * @param text text to parse
      * @return LocalDateTime
@@ -146,7 +148,8 @@ final class DateTimeUtil {
     }
 
     /**
-     * Non-throwing storage parse with fallback to input; returns null on failure.
+     * Parses storage text with fallback to input;
+     * Returns null on failure.
      *
      * @param text text to parse
      * @return LocalDateTime or null
@@ -162,7 +165,8 @@ final class DateTimeUtil {
     }
 
     /**
-     * Non-throwing parse to LocalDate; returns null on failure.
+     * Parses input string to LocalDate;
+     * Returns null on failure.
      *
      * @param raw input text
      * @return LocalDate or null
@@ -186,8 +190,9 @@ final class DateTimeUtil {
     }
 
     /**
-     * True if the given calendar date intersects [start, end] by date (inclusive).
-     * If start > end, the method swaps them.
+     * Returns True if the given calendar date intersects
+     * [start, end] by date (inclusive).
+     * Swaps start with end if start > end.
      *
      * @param date date to test
      * @param start start date-time (inclusive)

--- a/src/main/java/tkit/Deadline.java
+++ b/src/main/java/tkit/Deadline.java
@@ -4,26 +4,26 @@ import java.time.LocalDateTime;
 
 /** Task type with a deadline date/time. */
 class Deadline extends Task {
-    private final LocalDateTime dueAt;
+    private final LocalDateTime dueDate;
 
     /**
      * Creates a deadline task.
      *
      * @param description user-visible text
-     * @param dueAt due date/time
+     * @param dueDate due date/time
      */
-    public Deadline(String description, LocalDateTime dueAt) {
+    public Deadline(String description, LocalDateTime dueDate) {
         super(TaskType.DEADLINE, description);
-        this.dueAt = dueAt;
+        this.dueDate = dueDate;
     }
 
     /** Returns the due date/time. */
-    public LocalDateTime getDueAt() {
-        return dueAt;
+    public LocalDateTime getDueDate() {
+        return dueDate;
     }
 
     @Override
     public String toString() {
-        return super.toString() + " (by: " + DateTimeUtil.pretty(dueAt) + ")";
+        return super.toString() + " (by: " + DateTimeUtil.pretty(dueDate) + ")";
     }
 }

--- a/src/main/java/tkit/Event.java
+++ b/src/main/java/tkit/Event.java
@@ -4,39 +4,39 @@ import java.time.LocalDateTime;
 
 /** Task type describing a time-ranged event. */
 class Event extends Task {
-    private final LocalDateTime from;
-    private final LocalDateTime to;
+    private final LocalDateTime fromDate;
+    private final LocalDateTime toDate;
 
     /**
      * Creates an event task.
      *
      * @param description user-visible text
-     * @param from start date/time
-     * @param to end date/time
+     * @param fromDate start date/time
+     * @param toDate end date/time
      */
-    public Event(String description, LocalDateTime from, LocalDateTime to) {
+    public Event(String description, LocalDateTime fromDate, LocalDateTime toDate) {
         super(TaskType.EVENT, description);
-        this.from = from;
-        this.to = to;
+        this.fromDate = fromDate;
+        this.toDate = toDate;
     }
 
     /** Returns the start date/time. */
-    public LocalDateTime getFrom() {
-        return from;
+    public LocalDateTime getFromDate() {
+        return fromDate;
     }
 
     /** Returns the end date/time. */
-    public LocalDateTime getTo() {
-        return to;
+    public LocalDateTime getToDate() {
+        return toDate;
     }
 
     @Override
     public String toString() {
         return super.toString()
-                + " (from: "
-                + DateTimeUtil.pretty(from)
-                + " to: "
-                + DateTimeUtil.pretty(to)
+                + " (fromDate: "
+                + DateTimeUtil.pretty(fromDate)
+                + " toDate: "
+                + DateTimeUtil.pretty(toDate)
                 + ")";
     }
 }

--- a/src/main/java/tkit/Parser.java
+++ b/src/main/java/tkit/Parser.java
@@ -34,7 +34,7 @@ final class Parser {
      * Behavior:
      *   Trims surrounding whitespace
      *   Splits on the first whitespace run into "command token" and "rest"
-     *   Classifies the token using {@link Command#fromInput(String)}
+     *   Classifies the token using {@link Command#getCommandFromInput(String)}
      *
      * @param line full input line
      * @return parsed command and remainder; never {@code null}
@@ -45,7 +45,7 @@ final class Parser {
             return new SplitCommand(Command.UNKNOWN, "");
         }
         String[] parts = normalized.split("\\s+", 2);
-        Command cmd = Command.fromInput(parts[0]);
+        Command cmd = Command.getCommandFromInput(parts[0]);
         String rest = parts.length > 1 ? parts[1] : "";
         return new SplitCommand(cmd, rest);
     }

--- a/src/main/java/tkit/Storage.java
+++ b/src/main/java/tkit/Storage.java
@@ -14,12 +14,12 @@ import java.util.List;
 
 /**
  * Encapsulates reading from and writing to an OS-independent relative file path.
- * Format (pipe-delimited with escaping):
+ * Format (pipe-delimited with isEscaping):
  *   TYPE | DONE | DESCRIPTION | OTHER...
  *   T | 1 | read book
  *   D | 0 | return book | 2019-12-02T18:00
  *   E | 0 | project meeting | 2019-12-02T14:00 | 2019-12-02T16:00
- * Escaping rules:
+ * isEscaping rules:
  *   {@code \|} represents a literal pipe within a field
  *   {@code \\} represents a literal backslash
  * Corrupted lines are skipped without aborting, but counted for diagnostics.
@@ -81,30 +81,54 @@ final class Storage {
     }
 
     /**
-     * Persists all tasks to disk using a temp file then an atomic move (with non-atomic fallback).
-     * Preempts file saving issues that might arise due to runtime crashes
+     * Persists all tasks to disk. Writes to a temporary file first and then moves it into place atomically
+     * (with a non-atomic fallback) to minimize the risk of partial writes.
      *
-     * @param tasks current snapshot of tasks to save
+     * @param tasks the current snapshot of tasks to save; must not be {@code null}
      */
-    public void save(List<Task> tasks) {
+    public void save(final List<Task> tasks) {
         ensureParentDir();
-        Path tmp = dataFile.resolveSibling(dataFile.getFileName() + ".tmp");
+        final Path tmp = dataFile.resolveSibling(dataFile.getFileName() + ".tmp");
 
+        if (!writeSnapshot(tmp, tasks)) {
+            return;
+        }
+
+        finalizeSave(tmp);
+    }
+
+    /**
+     * Writes a header and all tasks to the given temporary file using UTF-8 encoding.
+     * Logs a warning and returns {@code false} on failure; otherwise returns {@code true}.
+     *
+     * @param tmp   the path to the temporary file that will hold the snapshot
+     * @param tasks the tasks to be serialized into the file
+     * @return {@code true} if the snapshot was written successfully; {@code false} otherwise
+     */
+    private boolean writeSnapshot(final Path tmp, final List<Task> tasks) {
         try (BufferedWriter writer = Files.newBufferedWriter(tmp, StandardCharsets.UTF_8)) {
             writer.write(HEADER_PREFIX + " Tkit save @ " + LocalDateTime.now());
             writer.newLine();
-
             for (Task t : tasks) {
                 writer.write(encodeTask(t));
                 writer.newLine();
             }
+            return true;
         } catch (IOException io) {
             System.out.println("____________________\n");
             System.out.println("Warning: failed to write data file: " + io.getMessage());
             System.out.println("____________________\n");
-            return;
+            return false;
         }
+    }
 
+    /**
+     * Moves the temporary snapshot file into place as the main data file. Attempts an atomic move first;
+     * if the filesystem does not support it, falls back to a non-atomic replace. Logs warnings on failure.
+     *
+     * @param tmp the path to the temporary file to move into place
+     */
+    private void finalizeSave(final Path tmp) {
         try {
             Files.move(
                     tmp,
@@ -126,6 +150,7 @@ final class Storage {
             System.out.println("____________________\n");
         }
     }
+
 
     /** Ensures parent directory exists; creates it if missing. */
     private void ensureParentDir() {
@@ -154,13 +179,13 @@ final class Storage {
         if (t instanceof Deadline) {
             Deadline d = (Deadline) t;
             sb.append(" | ")
-                    .append(escape(DateTimeUtil.toStorage(d.getDueAt())));
+                    .append(escape(DateTimeUtil.toStorage(d.getDueDate())));
         } else if (t instanceof Event) {
             Event e = (Event) t;
             sb.append(" | ")
-                    .append(escape(DateTimeUtil.toStorage(e.getFrom())))
+                    .append(escape(DateTimeUtil.toStorage(e.getFromDate())))
                     .append(" | ")
-                    .append(escape(DateTimeUtil.toStorage(e.getTo())));
+                    .append(escape(DateTimeUtil.toStorage(e.getToDate())));
         }
 
         return sb.toString();
@@ -234,19 +259,19 @@ final class Storage {
     /** Reverses {@link #escape(String)} on a field. */
     private static String unescape(String s) {
         StringBuilder out = new StringBuilder();
-        boolean escaping = false;
+        boolean isEscaping = false;
         for (int i = 0; i < s.length(); i++) {
             char c = s.charAt(i);
-            if (escaping) {
+            if (isEscaping) {
                 out.append(c);
-                escaping = false;
+                isEscaping = false;
             } else if (c == '\\') {
-                escaping = true;
+                isEscaping = true;
             } else {
                 out.append(c);
             }
         }
-        if (escaping) {
+        if (isEscaping) {
             out.append('\\');
         }
         return out.toString();
@@ -256,19 +281,19 @@ final class Storage {
     private static List<String> splitPreservingEscapes(String line) {
         List<String> fields = new ArrayList<>();
         StringBuilder current = new StringBuilder();
-        boolean escaping = false;
+        boolean isEscaping = false;
 
         for (int i = 0; i < line.length(); i++) {
             char c = line.charAt(i);
 
-            if (escaping) {
+            if (isEscaping) {
                 current.append(c);
-                escaping = false;
+                isEscaping = false;
                 continue;
             }
 
             if (c == '\\') {
-                escaping = true;
+                isEscaping = true;
                 continue;
             }
 

--- a/src/main/java/tkit/TaskList.java
+++ b/src/main/java/tkit/TaskList.java
@@ -136,12 +136,12 @@ final class TaskList {
         List<Task> hits = new ArrayList<>();
         for (Task t : tasks) {
             if (t instanceof Deadline) {
-                if (((Deadline) t).getDueAt().toLocalDate().equals(date)) {
+                if (((Deadline) t).getDueDate().toLocalDate().equals(date)) {
                     hits.add(t);
                 }
             } else if (t instanceof Event) {
-                LocalDateTime from = ((Event) t).getFrom();
-                LocalDateTime to = ((Event) t).getTo();
+                LocalDateTime from = ((Event) t).getFromDate();
+                LocalDateTime to = ((Event) t).getToDate();
                 if (DateTimeUtil.dateIntersects(date, from, to)) {
                     hits.add(t);
                 }


### PR DESCRIPTION
Codebase is not compliant with the Java coding standards. Need to align naming and documentation with Java coding standard; reduce method length, and improve readability.

Changes:
- Storage.java: rename 'escaping' -> 'isEscaping'
- Storage.java: split 'save' into 'save', 'writeSnapshot', 'finalizeSave'
- DateTimeUtil.java: revise Javadoc to standard format
- Deadline.java: rename 'dueAt' -> 'dueDate'
- Event.java: rename 'from' -> 'fromDate', 'to' -> 'toDate'
- Parser.java: rename 'fromInput' -> 'getCommandFromInput'